### PR TITLE
Fix health data point encode decode

### DIFF
--- a/packages/health/lib/src/health_data_point.dart
+++ b/packages/health/lib/src/health_data_point.dart
@@ -14,17 +14,8 @@ class HealthDataPoint {
   String _sourceId;
   String _sourceName;
 
-  HealthDataPoint(
-      this._value,
-      this._type,
-      this._unit,
-      this._dateFrom,
-      this._dateTo,
-      this._platform,
-      this._deviceId,
-      this._deviceModel,
-      this._sourceId,
-      this._sourceName) {
+  HealthDataPoint(this._value, this._type, this._unit, this._dateFrom, this._dateTo, this._platform, this._deviceId,
+      this._deviceModel, this._sourceId, this._sourceName) {
     // set the value to minutes rather than the category
     // returned by the native API
     if (type == HealthDataType.MINDFULNESS ||
@@ -50,21 +41,19 @@ class HealthDataPoint {
     HealthValue healthValue;
     if (json['data_type'] == 'audiogram') {
       healthValue = AudiogramHealthValue.fromJson(json['value']);
+    } else if (json['data_type'] == 'WORKOUT') {
+      healthValue = WorkoutHealthValue.fromJson(json['value']);
     } else {
       healthValue = NumericHealthValue.fromJson(json['value']);
     }
 
     return HealthDataPoint(
         healthValue,
-        HealthDataType.values.firstWhere(
-            (element) => element.typeToString() == json['data_type']),
-        HealthDataUnit.values
-            .firstWhere((element) => element.typeToString() == json['unit']),
+        HealthDataType.values.firstWhere((element) => element.typeToString() == json['data_type']),
+        HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['unit']),
         DateTime.parse(json['date_from']),
         DateTime.parse(json['date_to']),
-        PlatformTypeJsonValue.keys.toList()[PlatformTypeJsonValue.values
-            .toList()
-            .indexOf(json['platform_type'])],
+        PlatformTypeJsonValue.keys.toList()[PlatformTypeJsonValue.values.toList().indexOf(json['platform_type'])],
         json['device_id'],
         json['device_model'],
         json['source_id'],
@@ -80,7 +69,7 @@ class HealthDataPoint {
         'date_to': dateTo.toIso8601String(),
         'platform_type': PlatformTypeJsonValue[platform],
         'device_id': deviceId,
-        'device_model' : deviceModel,
+        'device_model': deviceModel,
         'source_id': sourceId,
         'source_name': sourceName
       };
@@ -150,6 +139,6 @@ class HealthDataPoint {
   }
 
   @override
-  int get hashCode => Object.hash(value, unit, dateFrom, dateTo, type, platform,
-      deviceId, deviceModel, sourceId, sourceName);
+  int get hashCode =>
+      Object.hash(value, unit, dateFrom, dateTo, type, platform, deviceId, deviceModel, sourceId, sourceName);
 }

--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -122,11 +122,11 @@ class WorkoutHealthValue extends HealthValue {
   factory WorkoutHealthValue.fromJson(json) {
     return WorkoutHealthValue(
         HealthWorkoutActivityType.values.firstWhere((element) => element.typeToString() == json['workoutActivityType']),
-        json['totalEnergyBurned'] != null ? json['totalEnergyBurned'] as int : null,
+        json['totalEnergyBurned'] != null ? (json['totalEnergyBurned'] as num).toInt() : null,
         json['totalEnergyBurnedUnit'] != null
             ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalEnergyBurnedUnit'])
             : null,
-        json['totalDistance'] != null ? json['totalDistance'] as int : null,
+        json['totalDistance'] != null ? (json['totalDistance'] as num).toInt() : null,
         json['totalDistanceUnit'] != null
             ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalDistanceUnit'])
             : null);

--- a/packages/health/lib/src/health_value_types.dart
+++ b/packages/health/lib/src/health_value_types.dart
@@ -46,8 +46,7 @@ class AudiogramHealthValue extends HealthValue {
   List<num> _leftEarSensitivities;
   List<num> _rightEarSensitivities;
 
-  AudiogramHealthValue(this._frequencies, this._leftEarSensitivities,
-      this._rightEarSensitivities);
+  AudiogramHealthValue(this._frequencies, this._leftEarSensitivities, this._rightEarSensitivities);
 
   List<num> get frequencies => _frequencies;
   List<num> get leftEarSensitivities => _leftEarSensitivities;
@@ -61,9 +60,7 @@ class AudiogramHealthValue extends HealthValue {
   }
 
   factory AudiogramHealthValue.fromJson(json) {
-    return AudiogramHealthValue(
-        List<num>.from(json['frequencies']),
-        List<num>.from(json['leftEarSensitivities']),
+    return AudiogramHealthValue(List<num>.from(json['frequencies']), List<num>.from(json['leftEarSensitivities']),
         List<num>.from(json['rightEarSensitivities']));
   }
 
@@ -82,8 +79,7 @@ class AudiogramHealthValue extends HealthValue {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(frequencies, leftEarSensitivities, rightEarSensitivities);
+  int get hashCode => Object.hash(frequencies, leftEarSensitivities, rightEarSensitivities);
 }
 
 /// A [HealthValue] object for workouts
@@ -101,12 +97,8 @@ class WorkoutHealthValue extends HealthValue {
   int? _totalDistance;
   HealthDataUnit? _totalDistanceUnit;
 
-  WorkoutHealthValue(
-      this._workoutActivityType,
-      this._totalEnergyBurned,
-      this._totalEnergyBurnedUnit,
-      this._totalDistance,
-      this._totalDistanceUnit);
+  WorkoutHealthValue(this._workoutActivityType, this._totalEnergyBurned, this._totalEnergyBurnedUnit,
+      this._totalDistance, this._totalDistanceUnit);
 
   /// The type of the workout.
   HealthWorkoutActivityType get workoutActivityType => _workoutActivityType;
@@ -129,40 +121,33 @@ class WorkoutHealthValue extends HealthValue {
 
   factory WorkoutHealthValue.fromJson(json) {
     return WorkoutHealthValue(
-        HealthWorkoutActivityType.values.firstWhere(
-            (element) => element.typeToString() == json['workoutActivityType']),
-        json['totalEnergyBurned'] != null
-            ? (json['totalEnergyBurned'] as double).toInt()
-            : null,
+        HealthWorkoutActivityType.values.firstWhere((element) => element.typeToString() == json['workoutActivityType']),
+        json['totalEnergyBurned'] != null ? json['totalEnergyBurned'] as int : null,
         json['totalEnergyBurnedUnit'] != null
-            ? HealthDataUnit.values.firstWhere((element) =>
-                element.typeToString() == json['totalEnergyBurnedUnit'])
+            ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalEnergyBurnedUnit'])
             : null,
-        json['totalDistance'] != null
-            ? (json['totalDistance'] as double).toInt()
-            : null,
+        json['totalDistance'] != null ? json['totalDistance'] as int : null,
         json['totalDistanceUnit'] != null
-            ? HealthDataUnit.values.firstWhere((element) =>
-                element.typeToString() == json['totalDistanceUnit'])
+            ? HealthDataUnit.values.firstWhere((element) => element.typeToString() == json['totalDistanceUnit'])
             : null);
   }
 
   @override
   Map<String, dynamic> toJson() => {
-        'workoutActivityType': _workoutActivityType.toString(),
+        'workoutActivityType': _workoutActivityType.typeToString(),
         'totalEnergyBurned': _totalEnergyBurned,
-        'totalEnergyBurnedUnit': _totalEnergyBurnedUnit?.toString(),
+        'totalEnergyBurnedUnit': _totalEnergyBurnedUnit?.typeToString(),
         'totalDistance': _totalDistance,
-        'totalDistanceUnit': _totalDistanceUnit?.toString(),
+        'totalDistanceUnit': _totalDistanceUnit?.typeToString(),
       };
 
   @override
   String toString() {
-    return """workoutActivityType: ${workoutActivityType.toString()},
+    return """workoutActivityType: ${workoutActivityType.typeToString()},
     totalEnergyBurned: $totalEnergyBurned,
-    totalEnergyBurnedUnit: ${totalEnergyBurnedUnit?.toString()},
+    totalEnergyBurnedUnit: ${totalEnergyBurnedUnit?.typeToString()},
     totalDistance: $totalDistance,
-    totalDistanceUnit: ${totalDistanceUnit?.toString()}""";
+    totalDistanceUnit: ${totalDistanceUnit?.typeToString()}""";
   }
 
   @override
@@ -176,8 +161,8 @@ class WorkoutHealthValue extends HealthValue {
   }
 
   @override
-  int get hashCode => Object.hash(workoutActivityType, totalEnergyBurned,
-      totalEnergyBurnedUnit, totalDistance, totalDistanceUnit);
+  int get hashCode =>
+      Object.hash(workoutActivityType, totalEnergyBurned, totalEnergyBurnedUnit, totalDistance, totalDistanceUnit);
 }
 
 abstract class HealthValue {


### PR DESCRIPTION
resolve issue: https://github.com/cph-cachet/flutter-plugins/issues/598

factory HealthDataPoint.fromJson(json) does not separate NumericHealthValue and WorkoutHealthValue causing the crash while processing workout data type.
```
{
  "value": {
    "workoutActivityType": "TRADITIONAL_STRENGTH_TRAINING",
    "totalEnergyBurned": 1027,
    "totalEnergyBurnedUnit": "KILOCALORIE",
    "totalDistance": null,
    "totalDistanceUnit": "METER"
  },
  "data_type": "WORKOUT"
  ...
}
```